### PR TITLE
refactor: RequestFactory struct에서 enum으로 변경

### DIFF
--- a/BBus/BBus.xcodeproj/project.pbxproj
+++ b/BBus/BBus.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		4A5182BD27551F40001EA530 /* GetFavoriteItemListUsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5182BC27551F40001EA530 /* GetFavoriteItemListUsable.swift */; };
 		4A5182BF27551F57001EA530 /* CreateFavoriteItemUsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5182BE27551F57001EA530 /* CreateFavoriteItemUsable.swift */; };
 		4A5182C127551F6D001EA530 /* DeleteFavoriteItemUsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5182C027551F6D001EA530 /* DeleteFavoriteItemUsable.swift */; };
+		4A67AB82283776B0006310D4 /* BBusAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A38E20627463FF7003A9D10 /* BBusAPIError.swift */; };
 		4A7BBFED2737885F0029915F /* StationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7BBFEC2737885F0029915F /* StationHeaderView.swift */; };
 		4A7BBFEF27378AA50029915F /* StationBodyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7BBFEE27378AA50029915F /* StationBodyCollectionViewCell.swift */; };
 		4A7BBFF12737D6C20029915F /* RemainCongestionBadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7BBFF02737D6C20029915F /* RemainCongestionBadgeLabel.swift */; };
@@ -1872,6 +1873,7 @@
 				4A2634C22756863600267B47 /* StationCalculatable.swift in Sources */,
 				4A2634BC2756759700267B47 /* AlarmSettingBusArriveInfo.swift in Sources */,
 				4A2634B1275670C500267B47 /* FavoriteItemDTO.swift in Sources */,
+				4A67AB82283776B0006310D4 /* BBusAPIError.swift in Sources */,
 				4A2634B3275670D100267B47 /* StationDTO.swift in Sources */,
 				4A2634BA2756757F00267B47 /* PublisherExtension.swift in Sources */,
 				4A2634BE275675C400267B47 /* BusRemainTime.swift in Sources */,

--- a/BBus/BBus/Background/GetOnAlarm/GetOnAlarmController.swift
+++ b/BBus/BBus/Background/GetOnAlarm/GetOnAlarmController.swift
@@ -37,7 +37,7 @@ final class GetOnAlarmController {
             let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                               persistenceStorage: PersistenceStorage(),
                                               tokenManageType: TokenManager.self,
-                                              requestFactory: RequestFactory())
+                                              requestFactory: RequestFactory.self)
             let useCase = GetOnAlarmAPIUseCase(useCases: apiUseCases)
             let getOnAlarmStatus = GetOnAlarmStatus(currentBusOrd: nil,
                                                     targetOrd: targetOrd,

--- a/BBus/BBus/Foreground/AlarmSetting/AlarmSettingCoordinator.swift
+++ b/BBus/BBus/Foreground/AlarmSetting/AlarmSettingCoordinator.swift
@@ -20,7 +20,7 @@ final class AlarmSettingCoordinator: Coordinator {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let apiUseCase = AlarmSettingAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = AlarmSettingCalculateUseCase()
         let viewModel = AlarmSettingViewModel(apiUseCase: apiUseCase,

--- a/BBus/BBus/Foreground/BusRoute/BusRouteCoordinator.swift
+++ b/BBus/BBus/Foreground/BusRoute/BusRouteCoordinator.swift
@@ -19,7 +19,7 @@ final class BusRouteCoordinator: StationPushable {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let useCase = BusRouteAPIUseCase(useCases: apiUseCases)
         let viewModel = BusRouteViewModel(useCase: useCase, busRouteId: busRouteId)
         let viewController = BusRouteViewController(viewModel: viewModel)

--- a/BBus/BBus/Foreground/Home/HomeCoordinator.swift
+++ b/BBus/BBus/Foreground/Home/HomeCoordinator.swift
@@ -19,7 +19,7 @@ final class HomeCoordinator: SearchPushable, BusRoutePushable, AlarmSettingPusha
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let apiUseCase = HomeAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = HomeCalculateUseCase()
         let viewModel = HomeViewModel(apiUseCase: apiUseCase, calculateUseCase: calculateUseCase)

--- a/BBus/BBus/Foreground/Search/SearchCoordinator.swift
+++ b/BBus/BBus/Foreground/Search/SearchCoordinator.swift
@@ -19,7 +19,7 @@ final class SearchCoordinator: BusRoutePushable, StationPushable {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let apiUseCase = SearchAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = SearchCalculateUseCase()
         let viewModel = SearchViewModel(apiUseCase: apiUseCase, calculateUseCase: calculateUseCase)

--- a/BBus/BBus/Foreground/Station/StationCoordinator.swift
+++ b/BBus/BBus/Foreground/Station/StationCoordinator.swift
@@ -19,7 +19,7 @@ final class StationCoordinator: BusRoutePushable, AlarmSettingPushable {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let apiUseCase = StationAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = StationCalculateUseCase()
         let viewModel = StationViewModel(apiUseCase: apiUseCase,

--- a/BBus/BBus/Global/Coordinator/AppCoordinator.swift
+++ b/BBus/BBus/Global/Coordinator/AppCoordinator.swift
@@ -74,7 +74,7 @@ extension AppCoordinator: MovingStatusOpenCloseDelegate {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let apiUseCase = MovingStatusAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = MovingStatusCalculateUseCase()
         let viewModel = MovingStatusViewModel(apiUseCase: apiUseCase,
@@ -96,7 +96,7 @@ extension AppCoordinator: MovingStatusOpenCloseDelegate {
         let apiUseCases = BBusAPIUseCases(networkService: NetworkService(),
                                           persistenceStorage: PersistenceStorage(),
                                           tokenManageType: TokenManager.self,
-                                          requestFactory: RequestFactory())
+                                          requestFactory: RequestFactory.self)
         let apiUseCase = MovingStatusAPIUseCase(useCases: apiUseCases)
         let calculateUseCase = MovingStatusCalculateUseCase()
         let viewModel = MovingStatusViewModel(apiUseCase: apiUseCase,

--- a/BBus/BBus/Global/Network/AccessKey.xcconfig
+++ b/BBus/BBus/Global/Network/AccessKey.xcconfig
@@ -8,5 +8,14 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-API_ACCESS_KEY2 = aaa
-API_ACCESS_KEY = aaa
+API_ACCESS_KEY1 = aaa
+API_ACCESS_KEY2 = bbb
+API_ACCESS_KEY3 = ccc
+API_ACCESS_KEY4 = ddd
+API_ACCESS_KEY5 = eee
+API_ACCESS_KEY6 = fff
+API_ACCESS_KEY7 = g
+API_ACCESS_KEY8 = h
+API_ACCESS_KEY9 = i
+API_ACCESS_KEY10 = j
+API_ACCESS_KEY11 = k

--- a/BBus/BBus/Global/Network/BBusAPIUseCases/BBusAPIUseCases.swift
+++ b/BBus/BBus/Global/Network/BBusAPIUseCases/BBusAPIUseCases.swift
@@ -13,9 +13,9 @@ struct BBusAPIUseCases {
     
     let networkService: NetworkServiceProtocol
     let persistenceStorage: PersistenceStorageProtocol
-    let requestFactory: Requestable
+    let requestFactory: Requestable.Type
     
-    init(networkService: NetworkServiceProtocol, persistenceStorage: PersistenceStorageProtocol, tokenManageType: TokenManagable.Type, requestFactory: Requestable) {
+    init(networkService: NetworkServiceProtocol, persistenceStorage: PersistenceStorageProtocol, tokenManageType: TokenManagable.Type, requestFactory: Requestable.Type) {
         self.networkService = networkService
         self.persistenceStorage = persistenceStorage
         self.tokenManageType = tokenManageType

--- a/BBus/BBus/Global/Network/Fetcher/GetArrInfoByRouteListFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetArrInfoByRouteListFetcher.swift
@@ -15,7 +15,7 @@ protocol GetArrInfoByRouteListFetchable {
 struct ServiceGetArrInfoByRouteListFetcher: ServiceFetchable, GetArrInfoByRouteListFetchable {
     private(set) var networkService: NetworkServiceProtocol
     private(set) var tokenManager: TokenManagable
-    private(set) var requestFactory: Requestable
+    private(set) var requestFactory: Requestable.Type
     
     func fetch(param: [String: String]) -> AnyPublisher<Data, Error> {
         let url = "http://ws.bus.go.kr/api/rest/arrive/getArrInfoByRoute"

--- a/BBus/BBus/Global/Network/Fetcher/GetBusPosByRtidFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetBusPosByRtidFetcher.swift
@@ -15,7 +15,7 @@ protocol GetBusPosByRtidFetchable {
 struct ServiceGetBusPosByRtidFetcher: ServiceFetchable, GetBusPosByRtidFetchable {
     private(set) var networkService: NetworkServiceProtocol
     private(set) var tokenManager: TokenManagable
-    private(set) var requestFactory: Requestable
+    private(set) var requestFactory: Requestable.Type
     
     func fetch(param: [String : String]) -> AnyPublisher<Data, Error> {
         let url = "http://ws.bus.go.kr/api/rest/buspos/getBusPosByRtid"

--- a/BBus/BBus/Global/Network/Fetcher/GetBusPosByVehIdFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetBusPosByVehIdFetcher.swift
@@ -15,7 +15,7 @@ protocol GetBusPosByVehIdFetchable {
 struct ServiceGetBusPosByVehIdFetcher: ServiceFetchable, GetBusPosByVehIdFetchable {
     private(set) var networkService: NetworkServiceProtocol
     private(set) var tokenManager: TokenManagable
-    private(set) var requestFactory: Requestable
+    private(set) var requestFactory: Requestable.Type
     
     func fetch(param: [String: String]) -> AnyPublisher<Data, Error> {
         let url = "http://ws.bus.go.kr/api/rest/buspos/getBusPosByVehId"

--- a/BBus/BBus/Global/Network/Fetcher/GetRouteInfoItemFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetRouteInfoItemFetcher.swift
@@ -15,7 +15,7 @@ protocol GetRouteInfoItemFetchable {
 struct ServiceGetRouteInfoItemFetcher: ServiceFetchable, GetRouteInfoItemFetchable {
     private(set) var networkService: NetworkServiceProtocol
     private(set) var tokenManager: TokenManagable
-    private(set) var requestFactory: Requestable
+    private(set) var requestFactory: Requestable.Type
     
     func fetch(param: [String : String]) -> AnyPublisher<Data, Error> {
         let url = "http://ws.bus.go.kr/api/rest/busRouteInfo/getRouteInfo"

--- a/BBus/BBus/Global/Network/Fetcher/GetStationByUidItemFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetStationByUidItemFetcher.swift
@@ -15,7 +15,7 @@ protocol GetStationByUidItemFetchable {
 struct ServiceGetStationByUidItemFetcher: ServiceFetchable, GetStationByUidItemFetchable {
     private(set) var networkService: NetworkServiceProtocol
     private(set) var tokenManager: TokenManagable
-    private(set) var requestFactory: Requestable
+    private(set) var requestFactory: Requestable.Type
     
     func fetch(param: [String : String]) -> AnyPublisher<Data, Error> {
         let url = "http://ws.bus.go.kr/api/rest/stationinfo/getStationByUid"

--- a/BBus/BBus/Global/Network/Fetcher/GetStationsByRouteListFetcher.swift
+++ b/BBus/BBus/Global/Network/Fetcher/GetStationsByRouteListFetcher.swift
@@ -15,7 +15,7 @@ protocol GetStationsByRouteListFetchable {
 struct ServiceGetStationsByRouteListFetcher: ServiceFetchable, GetStationsByRouteListFetchable {
     private(set) var networkService: NetworkServiceProtocol
     private(set) var tokenManager: TokenManagable
-    private(set) var requestFactory: Requestable
+    private(set) var requestFactory: Requestable.Type
     
     func fetch(param: [String : String]) -> AnyPublisher<Data, Error> {
         let url = "http://ws.bus.go.kr/api/rest/busRouteInfo/getStaionByRoute"

--- a/BBus/BBus/Global/Network/Fetcher/ServiceFetchable.swift
+++ b/BBus/BBus/Global/Network/Fetcher/ServiceFetchable.swift
@@ -11,7 +11,7 @@ import Combine
 protocol ServiceFetchable {
     var networkService: NetworkServiceProtocol { get }
     var tokenManager: TokenManagable { get }
-    var requestFactory: Requestable { get }
+    var requestFactory: Requestable.Type { get }
 
     func fetch(url: String, param: [String: String]) -> AnyPublisher<Data, Error>
 }

--- a/BBus/BBus/Global/Network/RequestFactory.swift
+++ b/BBus/BBus/Global/Network/RequestFactory.swift
@@ -8,11 +8,28 @@
 import Foundation
 
 protocol Requestable {
-    func request(url: String, accessKey: String, params: [String: String]) -> URLRequest?
+    static func request(url: String, accessKey: String, params: [String: String]) -> URLRequest?
 }
 
-struct RequestFactory: Requestable {
-    func request(url: String, accessKey: String, params: [String: String]) -> URLRequest? {
+//struct RequestFactory: Requestable {
+//    func request(url: String, accessKey: String, params: [String: String]) -> URLRequest? {
+//        guard var components = URLComponents(string: url) else { return nil }
+//        var items: [URLQueryItem] = []
+//        params.forEach() { item in
+//            items.append(URLQueryItem(name: item.key, value: item.value))
+//        }
+//        components.queryItems = items
+//        guard let query = components.percentEncodedQuery else { return nil }
+//        components.percentEncodedQuery = query + "&serviceKey=" + accessKey
+//        guard let url = components.url else { return nil }
+//        var request = URLRequest(url: url)
+//        request.httpMethod = "GET"
+//        return request
+//    }
+//}
+
+enum RequestFactory: Requestable {
+    static func request(url: String, accessKey: String, params: [String: String]) -> URLRequest? {
         guard var components = URLComponents(string: url) else { return nil }
         var items: [URLQueryItem] = []
         params.forEach() { item in

--- a/BBus/BBus/Global/Network/RequestFactory.swift
+++ b/BBus/BBus/Global/Network/RequestFactory.swift
@@ -11,23 +11,6 @@ protocol Requestable {
     static func request(url: String, accessKey: String, params: [String: String]) -> URLRequest?
 }
 
-//struct RequestFactory: Requestable {
-//    func request(url: String, accessKey: String, params: [String: String]) -> URLRequest? {
-//        guard var components = URLComponents(string: url) else { return nil }
-//        var items: [URLQueryItem] = []
-//        params.forEach() { item in
-//            items.append(URLQueryItem(name: item.key, value: item.value))
-//        }
-//        components.queryItems = items
-//        guard let query = components.percentEncodedQuery else { return nil }
-//        components.percentEncodedQuery = query + "&serviceKey=" + accessKey
-//        guard let url = components.url else { return nil }
-//        var request = URLRequest(url: url)
-//        request.httpMethod = "GET"
-//        return request
-//    }
-//}
-
 enum RequestFactory: Requestable {
     static func request(url: String, accessKey: String, params: [String: String]) -> URLRequest? {
         guard var components = URLComponents(string: url) else { return nil }

--- a/BBus/MovingStatusViewModelTests/MovingStatusViewModelTests.swift
+++ b/BBus/MovingStatusViewModelTests/MovingStatusViewModelTests.swift
@@ -263,8 +263,12 @@ class MovingStatusViewModelTests: XCTestCase {
 
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
+        let viewModel = MovingStatusViewModel(apiUseCase: DummyMovingStatusAPIUseCase(), calculateUseCase: MovingStatusCalculateUseCase(), busRouteId: 100100260, fromArsId: "21211", toArsId: "21210")
         measure {
             // Put the code you want to measure the time of here.
+            (0..<10).forEach() { _ in
+                viewModel.updateAPI()
+            }
         }
     }
 


### PR DESCRIPTION
## 작업 내용
- [x] RequestFactory 구조체에서 enum으로 변경
- [x] RequestFactory request function을 enum의 static function으로 변경

## 시연 방법
X

## 기타 (고민과 해결, 리뷰 포인트 등)
static function 또한 프로토콜을 사용해서 의존 관계를 독립시킨다면 테스트가 가능하다. 
일반적으로 메소드가 상태와 연관되어 있지 않은 경우, 그리고 타입 그 자체와 연관된 메소드인 경우 static function으로 구현되곤 한다. 
따라서 RequestFactory 구현의 경우 enum의 static function을 사용하는 것이 struct로 구현하는 것 보다 더 나은 방법이라고 판단했다.

상세 내용 → [[Swift] 프로퍼티가 없는 객체? Singleton Pattern, Static function 그리고 Struct](https://velog.io/@tmfrlrkvlek/%ED%94%84%EB%A1%9C%ED%8D%BC%ED%8B%B0%EA%B0%80-%EC%97%86%EB%8A%94-%EA%B0%9D%EC%B2%B4-Singleton-Pattern-Static-function-%EA%B7%B8%EB%A6%AC%EA%B3%A0-Struct)
